### PR TITLE
[CI/CD] CI: remove unnecessary build for CI checking types and lint

### DIFF
--- a/.github/workflows/check-types-and-lint.yml
+++ b/.github/workflows/check-types-and-lint.yml
@@ -7,13 +7,13 @@ name: Check Types and Lint
       - research
 
 jobs:
-  build_and_test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      - name: Create Production Build
-        run: yarn install --frozen-lockfile && yarn run build
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
       - name: Check Types
         run: yarn type-check
       - name: Lint


### PR DESCRIPTION
# Description

We do not need to build the project when checking types and lint.

# Changes

## CI/CD

- `Check Types and Lint` action: change the step `Create Production Build` to `Install Dependencies`

# Notes


# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] Any changes to strings have been published to our translation tool
- [x] I conducted basic QA to assure all features are working
- [ ] I requested code review from other team members

# Resolved Issues
