### PR TITLE
POI Report: open login modal when buttons for adding/editing report clicked and user not logged in

### DIFF
--- a/src/components/Drawer/AddReportDrawer/index.tsx
+++ b/src/components/Drawer/AddReportDrawer/index.tsx
@@ -24,10 +24,11 @@ const AddReportDrawer: React.FC = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const dispatch = useDispatch();
   const reportType = useSelector((state: IRootState) => state.report.type);
   const reportData = useSelector((state: IRootState) => state.report.data);
   const reportMedia = useSelector((state: IRootState) => state.report.media);
+
+  const dispatch = useDispatch();
 
   const [addPoi] = useAddPoiMutation();
 

--- a/src/components/Drawer/ClusterDrawer/index.tsx
+++ b/src/components/Drawer/ClusterDrawer/index.tsx
@@ -7,6 +7,7 @@ import { Button } from "@nextui-org/react";
 import { useGetClusterQuery } from "../../../api/cluster";
 import { useGetUserQuery } from "../../../api/user";
 import { IRootState } from "../../../store";
+import { openModal } from "../../../store/modal";
 import { addReport } from "../../../store/report";
 import {
   getParamsFromDrawer,
@@ -21,8 +22,9 @@ const ClusterDrawer: React.FC = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const dispatch = useDispatch();
   const reportType = useSelector((state: IRootState) => state.report.type);
+
+  const dispatch = useDispatch();
 
   const selected =
     !reportType && isCurrentDrawerParams("cluster", searchParams);
@@ -39,10 +41,10 @@ const ClusterDrawer: React.FC = () => {
     if (!id) {
       throw new Error("ClusterDrawer: id is null");
     } else if (!user?.id) {
-      throw new Error("ClusterDrawer: user id not found");
+      dispatch(openModal("login"));
+    } else {
+      dispatch(addReport({ clusterId: id, createBy: user?.id }));
     }
-
-    dispatch(addReport({ clusterId: id, createBy: user?.id }));
   };
 
   const handleDrawerDismiss = () => {

--- a/src/components/Drawer/EditReportDrawer/index.tsx
+++ b/src/components/Drawer/EditReportDrawer/index.tsx
@@ -23,11 +23,12 @@ const AddReportDrawer: React.FC = () => {
 
   const [searchParams] = useSearchParams();
 
-  const dispatch = useDispatch();
   const reportType = useSelector((state: IRootState) => state.report.type);
   const reportId = useSelector((state: IRootState) => state.report.id);
   const reportData = useSelector((state: IRootState) => state.report.data);
   const reportMedia = useSelector((state: IRootState) => state.report.media);
+
+  const dispatch = useDispatch();
 
   const [editPoi] = useUpdatePoiMutation();
 

--- a/src/components/Drawer/PoiDrawer/index.tsx
+++ b/src/components/Drawer/PoiDrawer/index.tsx
@@ -5,7 +5,9 @@ import { useSearchParams } from "react-router-dom";
 import { Button, Chip, Image } from "@nextui-org/react";
 
 import { useGetPoiQuery } from "../../../api/poi";
+import { useGetUserQuery } from "../../../api/user";
 import { IRootState } from "../../../store";
+import { openModal } from "../../../store/modal";
 import { editReport } from "../../../store/report";
 import {
   getParamsFromDrawer,
@@ -35,8 +37,9 @@ const PoiDrawer: React.FC = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const dispatch = useDispatch();
   const reportType = useSelector((state: IRootState) => state.report.type);
+
+  const dispatch = useDispatch();
 
   const selected = !reportType && isCurrentDrawerParams("poi", searchParams);
   const id = selected ? getParamsFromDrawer("poi", searchParams).poiId : null;
@@ -44,13 +47,16 @@ const PoiDrawer: React.FC = () => {
   const { data: poi } = useGetPoiQuery(id, {
     skip: !selected,
   });
+  const { data: user } = useGetUserQuery();
 
   const handleDrawerConfirm = () => {
     if (!poi) {
       throw new Error("ClusterDrawer: poi not found");
+    } else if (!user?.id) {
+      dispatch(openModal("login"));
+    } else {
+      dispatch(editReport(poi));
     }
-
-    dispatch(editReport(poi));
   };
 
   const handleDrawerDismiss = () => {


### PR DESCRIPTION
# Description

As title.

# Changes

## Cluster Drawer

When drawer confirm, check if user is logged in.
- If so, show the add report
- If not, show the login modal

## POI Drawer

When drawer confirm, check if user is logged in.
- If so, show the edit report
- If not, show the login modal

# Notes


# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] Any changes to strings have been published to our translation tool
- [x] I conducted basic QA to assure all features are working
- [ ] I requested code review from other team members

# Resolved Issues

#20 