### PR TITLE
[Research] POI Drawer: go to cluster drawer when closing poi drawer, and hide cluster marker when cluster drawer is shown.

### DIFF
--- a/src/components/Drawer/PoiDrawer/index.tsx
+++ b/src/components/Drawer/PoiDrawer/index.tsx
@@ -12,7 +12,7 @@ import { editReport } from "../../../store/report";
 import {
   getParamsFromDrawer,
   isCurrentDrawerParams,
-  resetDrawerParams,
+  setupDrawerParams,
 } from "../../../utils/routes/params";
 
 import { poiStatus, poiStatusMessageKeys } from "../../../constants/model/poi";
@@ -60,7 +60,15 @@ const PoiDrawer: React.FC = () => {
   };
 
   const handleDrawerDismiss = () => {
-    resetDrawerParams(searchParams, setSearchParams);
+    if (!poi) {
+      throw new Error("PoiDrawer: poi not found");
+    } else {
+      setupDrawerParams<"cluster">(
+        { clusterId: poi?.data.clusterId },
+        searchParams,
+        setSearchParams,
+      );
+    }
   };
 
   return (

--- a/src/components/Map/Markers/ClusterMarkers/index.tsx
+++ b/src/components/Map/Markers/ClusterMarkers/index.tsx
@@ -14,6 +14,10 @@ const ClusterMarkers: React.FC = () => {
 
   const { data: clusters } = useGetClustersQuery();
   const isCurrentSearchParamsPoi = isCurrentDrawerParams("poi", searchParams);
+  const isCurrentSearchParamsCluster = isCurrentDrawerParams(
+    "cluster",
+    searchParams,
+  );
 
   const handleClick = React.useCallback(
     (clusterId: string) =>
@@ -31,10 +35,19 @@ const ClusterMarkers: React.FC = () => {
       setOnClusterMarkerClick(handleClick);
     }
 
+    if (isCurrentSearchParamsCluster) {
+      markers.cluster.clear();
+    }
+
     return () => {
       markers.cluster.clear();
     };
-  }, [clusters, handleClick, isCurrentSearchParamsPoi]);
+  }, [
+    clusters,
+    handleClick,
+    isCurrentSearchParamsPoi,
+    isCurrentSearchParamsCluster,
+  ]);
   return <></>;
 };
 


### PR DESCRIPTION
# Description
1. when open a poi, clusters should be gone
2. when close a poi, we should go back to the situation that pois remain on map

# Changes
1. change handleDrawerDismiss function in src/components/Drawer/PoiDrawer/index.tsx
2. clear clusters after setPois()

# Notes
Modify for research need

# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] Any changes to strings have been published to our translation tool
- [ ] I conducted basic QA to assure all features are working
- [x] I requested code review from other team members

# Resolved Issues
#29 