### PR TITLE
[Refactor] Adjust image storage way

### DIFF
--- a/src/api/poi/index.ts
+++ b/src/api/poi/index.ts
@@ -79,7 +79,7 @@ const poiApiSlice = apiSlice.injectEndpoints({
     }),
     addPoi: builder.mutation<string, { data: PoiData }>({
       queryFn: async (arg) => {
-        const uploadPromises = arg.data.photoUrls.map((url) =>
+        const uploadPromises = arg.data.photoPaths.map((url) =>
           fetch(url)
             .then((res) => res.blob())
             .then(async (blob) => {
@@ -88,11 +88,11 @@ const poiApiSlice = apiSlice.injectEndpoints({
               return ref.fullPath;
             }),
         );
-        const photoUrls = await Promise.all(uploadPromises);
+        const photoPaths = await Promise.all(uploadPromises);
 
         const firebaseData = {
           ...toFirebasePoiDataByPoiData(arg.data),
-          photoUrls,
+          photoPaths,
           createdAt: Timestamp.now(),
         };
 

--- a/src/api/poi/index.ts
+++ b/src/api/poi/index.ts
@@ -25,8 +25,7 @@ import {
 
 import apiSlice from "..";
 import { generateImageStorageRef } from "../../utils/firebase/storage";
-import { getDownloadURL, getStorage, ref, uploadBytes } from "firebase/storage";
-import { firebaseApp } from "../../utils/firebase";
+import { uploadBytes } from "firebase/storage";
 
 const poiApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
@@ -89,17 +88,7 @@ const poiApiSlice = apiSlice.injectEndpoints({
               return ref.fullPath;
             }),
         );
-        const photoPaths = await Promise.all(uploadPromises);
-
-        const storage = getStorage(firebaseApp);
-
-        const photoUrls = await Promise.all(
-          photoPaths.map(async (path) => {
-            const url = await getDownloadURL(ref(storage, path));
-            // if we force it to store https here, it will cause error net::ERR_SSL_PROTOCOL_ERROR in local
-            return url;
-          }),
-        );
+        const photoUrls = await Promise.all(uploadPromises);
 
         const firebaseData = {
           ...toFirebasePoiDataByPoiData(arg.data),

--- a/src/components/Drawer/AddReportDrawer/AddReportDrawerContent.tsx
+++ b/src/components/Drawer/AddReportDrawer/AddReportDrawerContent.tsx
@@ -65,14 +65,14 @@ const AddReportDrawerContentPhotos: React.FC = () => {
 
     dispatch(
       updateAddReportData({
-        photoUrls: [...reportData.photoUrls, ...blobUrls],
+        photoPaths: [...reportData.photoPaths, ...blobUrls],
       }),
     );
   };
 
   return (
     <div className="flex flex-row">
-      {reportData.photoUrls.map((url) => (
+      {reportData.photoPaths.map((url) => (
         <Image key={url} src={url} alt="" />
       ))}
       <input type="file" multiple onChange={handleUpload} />

--- a/src/components/Drawer/EditReportDrawer/EditReportDrawerContent.tsx
+++ b/src/components/Drawer/EditReportDrawer/EditReportDrawerContent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Image, Input, Select, SelectItem } from "@nextui-org/react";
@@ -10,6 +10,8 @@ import {
 import { PoiStatusType } from "../../../models/poi";
 import { IRootState } from "../../../store";
 import { updateAddReportData } from "../../../store/report";
+import { getDownloadURL, ref, getStorage } from "firebase/storage";
+import { firebaseApp } from "../../../utils/firebase";
 
 const StatusSelect: React.FC = () => {
   const { t } = useTranslation();
@@ -17,8 +19,6 @@ const StatusSelect: React.FC = () => {
   const dispatch = useDispatch();
   const reportData = useSelector((state: IRootState) => state.report.data);
   const status = reportData.status.type;
-
-  console.log(reportData);
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value) {
@@ -54,10 +54,26 @@ const StatusSelect: React.FC = () => {
 
 const AddReportDrawerContentPhotos: React.FC = () => {
   const reportData = useSelector((state: IRootState) => state.report.data);
+  const [urls, setUrls] = useState<string[]>([]);
+  const storage = getStorage(firebaseApp);
+
+  useEffect(() => {
+    if (reportData?.photoPaths) {
+      const fetchUrls = async () => {
+        const urlPromises = reportData.photoPaths.map((path) =>
+          getDownloadURL(ref(storage, path)),
+        );
+        const resolvedUrls = await Promise.all(urlPromises);
+        setUrls(resolvedUrls);
+      };
+
+      fetchUrls();
+    }
+  }, [reportData, storage]);
 
   return (
     <div className="flex flex-row">
-      {reportData.photoPaths.map((url) => (
+      {urls.map((url) => (
         <Image key={url} src={url} alt="" />
       ))}
     </div>

--- a/src/components/Drawer/EditReportDrawer/EditReportDrawerContent.tsx
+++ b/src/components/Drawer/EditReportDrawer/EditReportDrawerContent.tsx
@@ -10,7 +10,7 @@ import {
 import { PoiStatusType } from "../../../models/poi";
 import { IRootState } from "../../../store";
 import { updateAddReportData } from "../../../store/report";
-import { getDownloadURL, ref, getStorage } from "firebase/storage";
+import { getDownloadURL, getStorage, ref } from "firebase/storage";
 import { firebaseApp } from "../../../utils/firebase";
 
 const StatusSelect: React.FC = () => {

--- a/src/components/Drawer/EditReportDrawer/EditReportDrawerContent.tsx
+++ b/src/components/Drawer/EditReportDrawer/EditReportDrawerContent.tsx
@@ -18,6 +18,8 @@ const StatusSelect: React.FC = () => {
   const reportData = useSelector((state: IRootState) => state.report.data);
   const status = reportData.status.type;
 
+  console.log(reportData);
+
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value) {
       dispatch(
@@ -55,7 +57,7 @@ const AddReportDrawerContentPhotos: React.FC = () => {
 
   return (
     <div className="flex flex-row">
-      {reportData.photoUrls.map((url) => (
+      {reportData.photoPaths.map((url) => (
         <Image key={url} src={url} alt="" />
       ))}
     </div>

--- a/src/components/Drawer/PoiDrawer/index.tsx
+++ b/src/components/Drawer/PoiDrawer/index.tsx
@@ -80,9 +80,9 @@ const PoiDrawer: React.FC = () => {
   const storage = getStorage(firebaseApp);
 
   useEffect(() => {
-    if (poi?.data.photoUrls) {
+    if (poi?.data.photoPaths) {
       const fetchUrls = async () => {
-        const urlPromises = poi.data.photoUrls.map((path) =>
+        const urlPromises = poi.data.photoPaths.map((path) =>
           getDownloadURL(ref(storage, path)),
         );
         const resolvedUrls = await Promise.all(urlPromises);

--- a/src/components/Drawer/PoiDrawer/index.tsx
+++ b/src/components/Drawer/PoiDrawer/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { useSearchParams } from "react-router-dom";
@@ -20,6 +20,8 @@ import {
   poiStatusTypeMessageKeys,
 } from "../../../constants/model/poi";
 import { PoiStatusType } from "../../../models/poi";
+import { getDownloadURL, ref, getStorage } from "firebase/storage";
+import { firebaseApp } from "../../../utils/firebase";
 
 import Drawer from "..";
 
@@ -74,6 +76,23 @@ const PoiDrawer: React.FC = () => {
     }
   };
 
+  const [urls, setUrls] = useState<string[]>([]);
+  const storage = getStorage(firebaseApp);
+
+  useEffect(() => {
+    if (poi?.data.photoUrls) {
+      const fetchUrls = async () => {
+        const urlPromises = poi.data.photoUrls.map((path) =>
+          getDownloadURL(ref(storage, path)),
+        );
+        const resolvedUrls = await Promise.all(urlPromises);
+        setUrls(resolvedUrls);
+      };
+
+      fetchUrls();
+    }
+  }, [poi, storage]);
+
   return (
     <Drawer
       open={selected}
@@ -99,7 +118,7 @@ const PoiDrawer: React.FC = () => {
           </div>
           <PoiDrawerStatus status={poi?.data.status.type} />
           <div className="flex flex-row">
-            {poi?.data.photoUrls.map((url) => (
+            {urls.map((url) => (
               <Image key={url} src={url} alt="" />
             ))}
           </div>

--- a/src/components/Drawer/PoiDrawer/index.tsx
+++ b/src/components/Drawer/PoiDrawer/index.tsx
@@ -20,7 +20,7 @@ import {
   poiStatusTypeMessageKeys,
 } from "../../../constants/model/poi";
 import { PoiStatusType } from "../../../models/poi";
-import { getDownloadURL, ref, getStorage } from "firebase/storage";
+import { getDownloadURL, getStorage, ref } from "firebase/storage";
 import { firebaseApp } from "../../../utils/firebase";
 
 import Drawer from "..";

--- a/src/models/firebase/firestore/index.ts
+++ b/src/models/firebase/firestore/index.ts
@@ -37,7 +37,7 @@ export interface FirestorePoiData {
   createdBy: string;
   updatedAt: Timestamp | null;
   updatedBy: string | null;
-  photoUrls: string[];
+  photoPaths: string[];
 }
 
 export interface FirestoreResource {

--- a/src/models/poi/index.ts
+++ b/src/models/poi/index.ts
@@ -28,7 +28,7 @@ export interface PoiData {
   createdBy: string;
   updatedAt: string | null;
   updatedBy: string | null;
-  photoUrls: string[];
+  photoPaths: string[];
 }
 
 export type Pois = Record<string, PoiData>;

--- a/src/store/report/index.ts
+++ b/src/store/report/index.ts
@@ -27,7 +27,7 @@ export const initialReportPoiData: PoiData = {
   createdBy: "",
   updatedAt: "",
   updatedBy: "",
-  photoUrls: [],
+  photoPaths: [],
 };
 
 const initialState: ReportState = {

--- a/src/utils/types/firebase/poi/index.ts
+++ b/src/utils/types/firebase/poi/index.ts
@@ -19,7 +19,7 @@ export const toFirebasePoiDataByPoiData = (poi: PoiData): FirestorePoiData => ({
   createdBy: poi.createdBy,
   updatedAt: poi.updatedAt ? Timestamp.fromDate(new Date(poi.updatedAt)) : null,
   updatedBy: poi.updatedBy,
-  photoUrls: poi.photoUrls,
+  photoPaths: poi.photoPaths,
 });
 
 export const toPoiDataByFirebasePoiData = (poi: FirestorePoiData): PoiData => ({
@@ -42,5 +42,5 @@ export const toPoiDataByFirebasePoiData = (poi: FirestorePoiData): PoiData => ({
   createdBy: poi.createdBy,
   updatedAt: poi.updatedAt?.toDate().toDateString() || null,
   updatedBy: poi.updatedBy,
-  photoUrls: poi.photoUrls,
+  photoPaths: poi.photoPaths,
 });


### PR DESCRIPTION
# Description
Change the image storage way from whole url to firebase storage path.

# Changes
We only store path in firestore now. e.g. `images/poi/320bdd5f-708f-48ae-bd5f-9c9d4e48279a`

# Notes
1. If we need the image, remember to use `getDownloadURL` to get the real url.
2. `photoUrls` already replace with `photoPaths`
3. Remember to change your `photoPaths` in script, when you want to test this PR.

# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] Any changes to strings have been published to our translation tool
- [x] I conducted basic QA to assure all features are working
- [x] I requested code review from other team members

# Resolved Issues
