### PR TITLE
[Hotfix] Fix blob cause getDownloadUrl cant find bug

### DIFF
--- a/src/components/Drawer/EditReportDrawer/EditReportDrawerContent.tsx
+++ b/src/components/Drawer/EditReportDrawer/EditReportDrawerContent.tsx
@@ -62,7 +62,9 @@ const AddReportDrawerContentPhotos: React.FC = () => {
     if (reportData?.photoPaths) {
       const fetchUrls = async () => {
         const urlPromises = reportData.photoPaths.map((path) =>
-          getDownloadURL(ref(storage, path)),
+          path.startsWith("blob:")
+            ? Promise.resolve(path)
+            : getDownloadURL(ref(storage, path)),
         );
         const resolvedUrls = await Promise.all(urlPromises);
         setUrls(resolvedUrls);


### PR DESCRIPTION
# Description
image Preview URL (blob) will cause getDownloadUrl can't find error, because blob url doesn't store in firestore.
<img width="819" alt="截圖 2023-11-20 下午10 15 33" src="https://github.com/CAMPUS-NYCU/smart-campus/assets/32840701/08c20ac5-d889-4848-b963-4ac6eefe8629">

# Changes
先判斷是否為 blob URL 才執行 getDownloadUrl 

# Notes

# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] Any changes to strings have been published to our translation tool
- [x] I conducted basic QA to assure all features are working
- [ ] I requested code review from other team members

# Resolved Issues
