### PR TITLE
[Research] Hotfix for the new cluster name

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -3,7 +3,8 @@
     "default": "smartcampus-prod",
     "prod": "smartcampus-prod",
     "dev": "smartcampus-dev",
-    "research": "smartcampus-research"
+    "research": "smartcampus-research",
+    "vanguard": "smartcampus-vanguard"
   },
   "targets": {},
   "etags": {}

--- a/.github/workflows/check-types-and-lint.yml
+++ b/.github/workflows/check-types-and-lint.yml
@@ -5,6 +5,7 @@ name: Check Types and Lint
       - prod
       - dev
       - research
+      - vanguard
 
 jobs:
   test:

--- a/.github/workflows/firebase-deploy-hosting-preview.yml
+++ b/.github/workflows/firebase-deploy-hosting-preview.yml
@@ -8,6 +8,8 @@ name: Deploy to Firebase Hosting in Preview Channel
       - prod
       - dev
       - research
+      - vanguard
+
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'

--- a/.github/workflows/firebase-deploy-hosting.yml
+++ b/.github/workflows/firebase-deploy-hosting.yml
@@ -8,7 +8,9 @@ name: Deploy to Firebase Hosting
       - prod
       - dev
       - research
+      - vanguard
   workflow_dispatch:
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/src/components/Drawer/ClusterDrawer/index.tsx
+++ b/src/components/Drawer/ClusterDrawer/index.tsx
@@ -25,7 +25,6 @@ import {
   poiStatusTypeMessageKeys,
   poiStatusValueMessageKeys,
 } from "../../../constants/model/poi";
-import { getDrawerTitle } from "../../../constants/drawerTitle";
 import { getDownloadURL, getStorage, ref } from "firebase/storage";
 import { firebaseApp } from "../../../utils/firebase";
 
@@ -245,7 +244,7 @@ const ClusterDrawer: React.FC = () => {
       open={selected}
       onClose={handleDrawerDismiss}
       title={t("clusterDrawer.title", {
-        name: cluster ? getDrawerTitle(cluster.data.name) : "",
+        name: cluster?.data.name,
         ns: ["drawer"],
       })}
       children={

--- a/src/constants/clusterCenter.ts
+++ b/src/constants/clusterCenter.ts
@@ -2,8 +2,12 @@ import centerData from "../assets/data/clusterCenters/clusterCenter.json";
 
 function getClusterCenter(clusterName: string) {
   if (clusterName) {
-    const matches = clusterName.match(/[^a-zA-Z\d]+/g);
-    const pureClusterName = matches ? matches.join("") : "";
+    // for research requirement. other cluster name may not be properly handled
+    // 1. remove the number after a Chinese character of the cluster name
+    // 2. remove the character from the dash (-) to the end of the cluster name
+    const pureClusterName = clusterName
+      .replace(/(\p{Script=Han})\d+/gu, "$1")
+      .replace(/-.*$/, "");
 
     const foundCenter = centerData.find(
       (center) => center.name === pureClusterName,
@@ -11,6 +15,9 @@ function getClusterCenter(clusterName: string) {
 
     if (foundCenter) {
       return foundCenter;
+    } else {
+      console.warn(`cluster center not found: ${clusterName}`);
+      return null;
     }
   }
 

--- a/src/constants/drawerTitle.ts
+++ b/src/constants/drawerTitle.ts
@@ -1,5 +1,8 @@
 function getDrawerTitle(clusterName: string) {
-  return clusterName.replace(/[0-9A-Za-z]+/g, "");
+  // for research requirement. other cluster name may not be properly handled
+  // 1. remove the number after a Chinese character of the cluster name
+  // 2. remove the dash (-) to the end of the cluster name
+  return clusterName.replace(/(\p{Script=Han})\d+/gu, "$1").replace(/-.*$/, "");
 }
 
 export { getDrawerTitle };

--- a/src/constants/drawerTitle.ts
+++ b/src/constants/drawerTitle.ts
@@ -1,7 +1,7 @@
 function getDrawerTitle(clusterName: string) {
   // for research requirement. other cluster name may not be properly handled
   // 1. remove the number after a Chinese character of the cluster name
-  // 2. remove the dash (-) to the end of the cluster name
+  // 2. remove the character from the dash (-) to the end of the cluster name
   return clusterName.replace(/(\p{Script=Han})\d+/gu, "$1").replace(/-.*$/, "");
 }
 

--- a/src/constants/entry.ts
+++ b/src/constants/entry.ts
@@ -3,8 +3,12 @@ import { EntryData } from "../models/entry";
 
 function getEntry(clusterName: string): EntryData | null {
   if (clusterName) {
-    const matches = clusterName.match(/[^a-zA-Z\d]+/g);
-    const pureClusterName = matches ? matches.join("") : "";
+    // for research requirement. other cluster name may not be properly handled
+    // 1. remove the number after a Chinese character of the cluster name
+    // 2. remove the character from the dash (-) to the end of the cluster name
+    const pureClusterName = clusterName
+      .replace(/(\p{Script=Han})\d+/gu, "$1")
+      .replace(/-.*$/, "");
 
     const foundEntry = entryData.find(
       (entry) => entry.name === pureClusterName,
@@ -13,6 +17,7 @@ function getEntry(clusterName: string): EntryData | null {
     if (foundEntry) {
       return foundEntry;
     } else {
+      console.warn(`entry not found: ${clusterName}`);
       return null;
     }
   }


### PR DESCRIPTION
# Description
- fix the cluster center and cluster entry for the new `clusterName`
  - e.g. 小木屋&校計中1 -> 小木屋&校計中2；圖書館-SHL-A -> 圖書館

# Changes
- src/constants/drawerTitle.ts
- src/constants/clusterCenter.ts
- src/constants/entry.ts

# Notes


# Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
- [ ] Any changes to strings have been published to our translation tool
- [ ] I conducted basic QA to assure all features are working
- [ ] I requested code review from other team members

# Resolved Issues
