### PR TITLE
[Research] remove the Chinese part of clusterName of clusterMarkers

### DIFF
--- a/src/utils/googleMaps/markers/cluster/index.ts
+++ b/src/utils/googleMaps/markers/cluster/index.ts
@@ -3,6 +3,21 @@ import { Clusters } from "../../../../models/cluster";
 import { maps } from "../..";
 import { getIcon } from "./icons";
 
+function getClusterSerial(clusterName: string): string {
+  if (clusterName !== "小木屋&校計中1" && clusterName !== "小木屋&校計中2") {
+    const match = clusterName.split("-");
+
+    if (match.length === 3) {
+      return `${match[1]}-${match[2]}`;
+    } else {
+      console.error(`找不到"${clusterName}"的serial`);
+      return "";
+    }
+  } else {
+    return clusterName;
+  }
+}
+
 export const markerRef = {
   current: {} as Record<string, google.maps.Marker>,
 };
@@ -18,7 +33,7 @@ export const setClusters = (clusters: Clusters): void => {
       new google.maps.Marker({
         icon: getIcon(),
         label: {
-          text: clusterData.name,
+          text: getClusterSerial(clusterData.name),
           fontFamily: "'Helvetica', 'Arial', 'sans-serif'",
           fontSize: "12px",
           color: "#FDCC4F",


### PR DESCRIPTION
# Description
- remove the Chinese part of clusterName of clusterMarkers

# Changes
- remove the Chinese part of clusterName of clusterMarkers
  - new
![image](https://github.com/CAMPUS-NYCU/smart-campus/assets/43398440/9ed550fd-cfff-44c9-b008-ef011d36b2fe)
  - old
![image](https://github.com/CAMPUS-NYCU/smart-campus/assets/43398440/4e4428bd-3e3c-4cf9-82b0-41bc5a935a6e)


# Notes


# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] Any changes to strings have been published to our translation tool
- [x] I conducted basic QA to assure all features are working
- [ ] I requested code review from other team members

# Resolved Issues
