### PR TITLE
[Research LLM] Reset highlighId when dismissing poi drawer

### DIFF
--- a/src/components/Drawer/PoiDrawer/index.tsx
+++ b/src/components/Drawer/PoiDrawer/index.tsx
@@ -29,6 +29,7 @@ import Drawer from "..";
 import { openModal } from "../../../store/modal";
 import { editReport } from "../../../store/report";
 import { useGetUserQuery } from "../../../api/user";
+import { resetHightlightId } from "../../../store/poi";
 
 const PoiDrawerStatus: React.FC<{
   statusType?: PoiStatusType | "";
@@ -94,6 +95,7 @@ const PoiDrawer: React.FC = () => {
         searchParams,
         setSearchParams,
       );
+      dispatch(resetHightlightId());
     }
   };
 


### PR DESCRIPTION
# Description
- fix the issue that the same poi cannot be clicked after closing poi drawer

# Changes


# Notes


# Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
- [ ] Any changes to strings have been published to our translation tool
- [ ] I conducted basic QA to assure all features are working
- [ ] I requested code review from other team members

# Resolved Issues
