### PR TITLE
[Research List] Fix initial state of filter and sorting

### DIFF
--- a/src/components/Drawer/ClusterDrawer/index.tsx
+++ b/src/components/Drawer/ClusterDrawer/index.tsx
@@ -272,6 +272,8 @@ const ClusterDrawer: React.FC = () => {
   React.useEffect(() => {
     if (!isCurrentDrawerParams("cluster", searchParams)) {
       dispatch(resetReport());
+      setSortingMethod(sortingOptions[0].key);
+      setSortingMessage(sortingMessages[0].message);
     }
   }, [dispatch, searchParams]);
 

--- a/src/components/Drawer/ClusterDrawer/index.tsx
+++ b/src/components/Drawer/ClusterDrawer/index.tsx
@@ -22,7 +22,6 @@ import { editReport, resetReport } from "../../../store/report";
 import {
   getParamsFromDrawer,
   isCurrentDrawerParams,
-  resetDrawerParams,
 } from "../../../utils/routes/params";
 
 import { getClusterIcon } from "../../../constants/clusterIcon";
@@ -46,11 +45,6 @@ import {
   sortingMessages,
 } from "../../../constants/sortingOptions";
 import UIPoi, { UIPoiData, UIPois } from "../../../models/uiPoi";
-import {
-  resetFilterPoiFloors,
-  resetFilterPoiStatuses,
-  resetFilterPoiTargetNames,
-} from "../../../store/filter";
 
 interface PoiListItemProps {
   poi: {
@@ -213,7 +207,7 @@ const PoiListItem: React.FC<PoiListItemProps> = (props) => {
 const ClusterDrawer: React.FC = () => {
   const { t } = useTranslation();
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
 
   const reportType = useSelector((state: IRootState) => state.report.type);
 
@@ -269,13 +263,6 @@ const ClusterDrawer: React.FC = () => {
       return null;
     }
   }, [filteredFloors, filteredStatuses, filteredTargetNames, queriedPoiList]);
-
-  const handleDrawerDismiss = () => {
-    resetDrawerParams(searchParams, setSearchParams);
-    dispatch(resetFilterPoiFloors());
-    dispatch(resetFilterPoiTargetNames());
-    dispatch(resetFilterPoiStatuses());
-  };
 
   const [sortingMethod, setSortingMethod] = useState(sortingOptions[0].key);
   const [sortingMessage, setSortingMessage] = useState(
@@ -343,7 +330,6 @@ const ClusterDrawer: React.FC = () => {
     <Drawer
       isDraggable={true}
       open={selected}
-      onClose={handleDrawerDismiss}
       title={t("clusterDrawer.title", {
         name: cluster?.data.name,
         ns: ["drawer"],

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 interface DrawerProps {
   children: React.ReactNode;
   open: boolean;
-  onClose: () => void;
+  onClose?: () => void;
   title: React.ReactNode;
   primaryButton?: React.ReactNode;
   secondaryButton?: React.ReactNode;

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -6,6 +6,8 @@ import { CloseIcon } from "../../utils/icons/drawer";
 import { drawerVariants, draggableDrawerVariants } from "./animation";
 import { Button } from "@nextui-org/react";
 import { useTranslation } from "react-i18next";
+import { isCurrentDrawerParams } from "../../utils/routes/params";
+import { useSearchParams } from "react-router-dom";
 
 interface DrawerProps {
   children: React.ReactNode;
@@ -42,6 +44,16 @@ const Drawer: React.FC<DrawerProps> = (props) => {
       setIsListShown(true);
     }
   };
+
+  const [searchParams] = useSearchParams();
+
+  React.useEffect(() => {
+    if (!isCurrentDrawerParams("cluster", searchParams)) {
+      if (isListShown) {
+        setIsListShown(false);
+      }
+    }
+  }, [isListShown, searchParams]);
 
   return (
     <>

--- a/src/components/Map/Fabs/UserFab/UserFabMenu/index.tsx
+++ b/src/components/Map/Fabs/UserFab/UserFabMenu/index.tsx
@@ -16,6 +16,11 @@ import {
 import { openModal } from "../../../../../store/modal";
 import { useSearchParams } from "react-router-dom";
 import { resetDrawerParams } from "../../../../../utils/routes/params";
+import {
+  resetFilterPoiFloors,
+  resetFilterPoiStatuses,
+  resetFilterPoiTargetNames,
+} from "../../../../../store/filter";
 
 const MenuItemUser: React.FC = () => {
   const { data: user } = useGetUserQuery();
@@ -65,6 +70,9 @@ const UserFabMenu: React.FC = () => {
 
   const handleBackToHome = () => {
     resetDrawerParams(searchParams, setSearchParams);
+    dispatch(resetFilterPoiFloors());
+    dispatch(resetFilterPoiTargetNames());
+    dispatch(resetFilterPoiStatuses());
   };
 
   return (


### PR DESCRIPTION
# Description
- initialize sorting and filter state after closing cluster drawer
- close drawer isListShown state after closing cluster drawer

# Changes
- filter
  - 因為是 redux 實作的，就把相關的 dispatch 丟到 userFab 的回主頁面那邊了
- sorting method
  - 他是只存在於 cluster drawer 中的 state，跟著 cluster drawer 原有的另一個判斷 cluster drawer 是否關閉 (searchParams 判斷) 的 useEffect 去重設
- isListShown
  -  在 drawer 多聽了一個 URL 判斷是否是 cluster 並 initialize isListShown
  - Improvement needed. add/edit/poi Drawer 和 cluster Drawer 應該要分開而不是用同一個 template 了

# Notes


# Checklist

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [ ] Any changes to strings have been published to our translation tool
- [X] I conducted basic QA to assure all features are working
- [X] I requested code review from other team members

# Resolved Issues
