### PR TITLE
[Research Basic] fix cluster panto issue when staying in the same cluster

### DIFF
--- a/src/components/Map/Markers/ClusterMarkers/index.tsx
+++ b/src/components/Map/Markers/ClusterMarkers/index.tsx
@@ -28,19 +28,23 @@ const ClusterMarkers: React.FC = () => {
     "cluster",
     searchParams,
   );
-  const [onClickedClusterName, setOnClickedClusterName] = React.useState("");
 
   const dispatch = useDispatch();
 
   const handleClick = React.useCallback(
     (clusterId: string) => {
       dispatch(openModal("reportStart"));
-      setOnClickedClusterName(clusters![clusterId].name);
       setupDrawerParams<"cluster">(
         { clusterId },
         searchParams,
         setSearchParams,
       );
+
+      const clusterCenter = getClusterCenter(clusters![clusterId].name)?.latlng;
+      if (clusterCenter) {
+        maps.panTo(clusterCenter.latitude, clusterCenter.longitude);
+      }
+      maps.setZoom(18);
     },
     [dispatch, clusters, searchParams, setSearchParams],
   );
@@ -55,15 +59,6 @@ const ClusterMarkers: React.FC = () => {
       setOnClusterMarkerClick(handleClick);
     }
 
-    if (isCurrentSearchParamsCluster && !isCurrentSearchParamsPoi) {
-      const clusterCenter = getClusterCenter(onClickedClusterName)?.latlng;
-      if (clusterCenter) {
-        maps.panTo(clusterCenter.latitude, clusterCenter.longitude);
-      }
-      maps.setZoom(18);
-      markers.cluster.clear();
-    }
-
     return () => {
       markers.cluster.clear();
     };
@@ -72,8 +67,6 @@ const ClusterMarkers: React.FC = () => {
     handleClick,
     isCurrentSearchParamsPoi,
     isCurrentSearchParamsCluster,
-    onClickedClusterName,
-    dispatch,
   ]);
   return (
     <>


### PR DESCRIPTION
# Description
- fix the issue that closing poi (which causes url changes) triggers the function of panTo cluster center

# Changes
- refactor the panTo function
  - move it into handle click, make sure panTo cluster center only happens when clusters are clicked

# Notes


# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [ ] Any changes to strings have been published to our translation tool
- [ ] I conducted basic QA to assure all features are working
- [ ] I requested code review from other team members

# Resolved Issues
